### PR TITLE
Fix key generation making use of ssh-dir option

### DIFF
--- a/ssh.bash
+++ b/ssh.bash
@@ -144,7 +144,7 @@ cmd_ssh() {
         die 'No ssh key selected.'
     fi
 
-    local private_key="$HOME/.ssh/$ssh_key"
+    local private_key="$ssh_dir/$ssh_key"
     local public_key="$private_key.pub"
 
     if ! [ -f "$public_key"  ]; then


### PR DESCRIPTION
SSH Key generation used the `-ssh-dir|-s` option to look for existing
keys but not in turn for the creation of new keys, since the path to
create the keys at was hard coded.

This commit makes pass-ssh obey the given ssh-dir for both search and
key generation.